### PR TITLE
fix(security): resolve final 2 CodeQL alerts #284 #285

### DIFF
--- a/src/agents/ingestion/citizen_ingestion_agent.py
+++ b/src/agents/ingestion/citizen_ingestion_agent.py
@@ -654,9 +654,6 @@ async def process_citizen_report_background(
     except Exception as e:
         logger.error(f"💥 Background task failed: {e}", exc_info=True)
 
-    except Exception as e:
-        logger.error(f"💥 Background task failed: {e}", exc_info=True)
-
 
 # ============================================================================
 # API Endpoints


### PR DESCRIPTION
## Summary
Resolves the final 2 remaining CodeQL security alerts:
- **#285 py/unreachable-except** at citizen_ingestion_agent.py:657 - Removed duplicate except block
- **#284 py/url-redirection** at content_negotiation_agent.py - Implemented secure token-based redirect

## Changes
1. **citizen_ingestion_agent.py**: Removed redundant duplicate \except Exception as e:\ block
2. **content_negotiation_agent.py**: 
   - Replaced direct entity_id usage in redirect with server-generated tokens
   - Added \/lookup/{ref_token}\ endpoint for secure entity resolution
   - Token approach completely breaks user input dataflow

## Security Improvements
- No user-controlled input flows into redirect URLs
- Server-generated \secrets.token_urlsafe()\ tokens are cryptographically secure
- Token cache auto-cleans to prevent memory leaks
- Same-origin validation still in place as defense-in-depth

## Testing
-  All unit tests pass
-  Code formatted with black
-  MIT license compatible

## Related
Closes #284
Closes #285